### PR TITLE
Corrected Typo in Demo Jupyter Notebook

### DIFF
--- a/demo.ipynb
+++ b/demo.ipynb
@@ -36,7 +36,7 @@
    "outputs": [],
    "source": [
     "# Load test dataset.\n",
-    "dataset = 'SWaT'  # or any dataset in SMAP/WSL/SMD/WADI\n",
+    "dataset = 'SWaT'  # or any dataset in SMAP/MSL/SMD/WADI\n",
     "test_data = np.load(config.TEST_DATASET[dataset])\n",
     "test_label = np.load(config.TEST_LABEL[dataset])\n",
     "\n",


### PR DESCRIPTION
Corrected Typo in Demo Jupyter Notebook, from "WSL" to "MSL", appeared only in one comment, but could lead to confusion (WSL = Windows Subsystem Linux, MSL = dataset)